### PR TITLE
Use Sandpack `updateFiles` to keep editor preview open

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,21 @@
 import { FlexItem, FlexLayout } from "@salt-ds/core";
 import { useState } from "react";
-import { CustomSandpack } from "./components/sandpack";
+import {
+  CustomSandpack,
+  DEFAULT_FILES,
+  dependencies,
+} from "./components/sandpack";
 import { ColorPickers } from "./components/visual-editor/ColorPickers";
 import { simpleSample } from "./themes/sample";
 
+import { SandpackProvider } from "@codesandbox/sandpack-react";
+
 import "./App.css";
 
-const App = () => {
+const InnerApp = () => {
   const [customTheme, setCustomTheme] = useState<any>(simpleSample);
-  console.log("App", customTheme);
+  console.log("InnerApp", customTheme);
+
   return (
     <FlexLayout>
       <FlexItem grow={1} shrink={1}>
@@ -21,6 +28,30 @@ const App = () => {
         <CustomSandpack themeObj={customTheme} />
       </FlexItem>
     </FlexLayout>
+  );
+};
+
+const App = () => {
+  return (
+    <SandpackProvider
+      template="react-ts"
+      theme="light"
+      customSetup={{
+        dependencies,
+      }}
+      files={DEFAULT_FILES}
+      options={{
+        classes: {
+          "sp-wrapper": "custom-wrapper",
+          "sp-layout": "custom-layout",
+          "sp-tab-button": "custom-tab",
+        },
+        // Custom bundler URL: https://sandpack.codesandbox.io/docs/guides/hosting-the-bundler
+        // bundlerURL: ''
+      }}
+    >
+      <InnerApp />
+    </SandpackProvider>
   );
 };
 export default App;

--- a/src/__tests__/themes/utils.spec.ts
+++ b/src/__tests__/themes/utils.spec.ts
@@ -67,6 +67,8 @@ describe("convertThemeObjToCss", () => {
       "--salt-palette-interact-background: rgb(255, 255, 255);",
       "--salt-palette-interact-background-hover: rgb(249, 224, 247);",
       "--salt-palette-interact-background-active: rgb(243, 189, 238);",
+      "--salt-palette-info-foreground: rgb(103, 46, 122);",
+      "--salt-palette-info-border: var(--salt-color-purple-700);",
     ]);
   });
 });

--- a/src/components/sandpack/CustomSandpack.tsx
+++ b/src/components/sandpack/CustomSandpack.tsx
@@ -17,7 +17,7 @@ import {
 const MutableKeyMap = completionKeymap.slice();
 
 const CustomLayout = () => {
-  const [showEditor, setShowEditor] = useState(false);
+  const [showEditor, setShowEditor] = useState(true);
   return (
     <StackLayout>
       <SandpackLayout>

--- a/src/components/sandpack/CustomSandpack.tsx
+++ b/src/components/sandpack/CustomSandpack.tsx
@@ -3,12 +3,16 @@ import {
   SandpackCodeEditor,
   SandpackLayout,
   SandpackPreview,
-  SandpackProvider,
+  useSandpack,
 } from "@codesandbox/sandpack-react";
 import { Button, StackLayout } from "@salt-ds/core";
-import { useState } from "react";
-import { convertThemeObjToCss } from "../../themes/utils";
-import { DEFAULT_FILES, dependencies } from "./custom-setup";
+import { useEffect, useState } from "react";
+import {
+  getCodeForCSS,
+  getCodeForJson,
+  THEME_FILE,
+  THEME_JSON,
+} from "./custom-setup";
 
 const MutableKeyMap = completionKeymap.slice();
 
@@ -37,42 +41,21 @@ const CustomLayout = () => {
   );
 };
 
-export const CustomSandpack = ({ themeObj }: any) => {
-  const defaultFiles = DEFAULT_FILES;
-  const convertedCode = convertThemeObjToCss(themeObj);
-  const code = `.custom-theme.salt-theme {
-  ${convertedCode.join("\n  ")}
-}`;
-  const files = {
-    ...defaultFiles,
-    "/Theme.css": {
-      code,
-    },
-    "/theme.json": {
-      code: JSON.stringify(themeObj, null, 2),
-      readOnly: true,
-    },
-  };
+const FilesUpdater = ({ theme }: any) => {
+  const { sandpack } = useSandpack();
+  useEffect(() => {
+    sandpack.updateFile(THEME_FILE, getCodeForCSS(theme), true);
+    sandpack.updateFile(THEME_JSON, getCodeForJson(theme), true);
+  }, [theme]);
 
+  return null;
+};
+
+export const CustomSandpack = ({ themeObj }: any) => {
   return (
-    <SandpackProvider
-      template="react-ts"
-      theme="light"
-      customSetup={{
-        dependencies,
-      }}
-      files={files}
-      options={{
-        classes: {
-          "sp-wrapper": "custom-wrapper",
-          "sp-layout": "custom-layout",
-          "sp-tab-button": "custom-tab",
-        },
-        // Custom bundler URL: https://sandpack.codesandbox.io/docs/guides/hosting-the-bundler
-        // bundlerURL: ''
-      }}
-    >
+    <>
+      <FilesUpdater theme={themeObj} />
       <CustomLayout />
-    </SandpackProvider>
+    </>
   );
 };

--- a/src/components/sandpack/custom-setup.ts
+++ b/src/components/sandpack/custom-setup.ts
@@ -1,6 +1,6 @@
 import { SandpackState } from "@codesandbox/sandpack-react";
-import { SALT_LIGHT_THEME } from "../../themes/saltLight";
-import { ThumbsUpIcon, ThumbsDownIcon, InfoIcon } from "@salt-ds/icons";
+import { simpleSample } from "../../themes/sample";
+import { convertThemeObjToCss } from "../../themes/utils";
 
 export const dependencies = {
   "@salt-ds/core": "latest",
@@ -8,6 +8,15 @@ export const dependencies = {
   "@salt-ds/lab": "latest",
   "@salt-ds/theme": "latest",
 };
+export const THEME_FILE = "/Theme.css";
+export const THEME_JSON = "/theme.json";
+
+export const getCodeForCSS = (theme: any) => `.custom-theme.salt-theme {
+  ${convertThemeObjToCss(theme).join("\n  ")}
+}`;
+
+export const getCodeForJson = (theme: any) => JSON.stringify(theme, null, 2);
+
 export const DEFAULT_FILES: SandpackState["files"] = {
   "/App.tsx": {
     code: `import { Button, SaltProvider, StackLayout, FlexLayout } from '@salt-ds/core';
@@ -96,5 +105,12 @@ root.render(
 </StrictMode>
 );`,
     // hidden: true,
+  },
+  [THEME_FILE]: {
+    code: getCodeForCSS(simpleSample),
+  },
+  [THEME_JSON]: {
+    code: getCodeForJson(simpleSample),
+    readOnly: true,
   },
 };

--- a/src/components/sandpack/custom-setup.ts
+++ b/src/components/sandpack/custom-setup.ts
@@ -19,7 +19,7 @@ export const getCodeForJson = (theme: any) => JSON.stringify(theme, null, 2);
 
 export const DEFAULT_FILES: SandpackState["files"] = {
   "/App.tsx": {
-    code: `import { Button, SaltProvider, StackLayout, FlexLayout } from '@salt-ds/core';
+    code: `import { Button, SaltProvider, StackLayout, FlexLayout, Tooltip } from '@salt-ds/core';
 import { InfoIcon, ThumbsUpIcon, ThumbsDownIcon } from '@salt-ds/icons';
 import { List } from '@salt-ds/lab';
 import "./Theme.css";
@@ -43,16 +43,18 @@ export default function App(): JSX.Element {
   return (
     <StackLayout>
       <List source={shortColorData} selected={shortColorData[3]} />
-      <FlexLayout>
+      <FlexLayout align="center">
         <Button variant="cta">
           <ThumbsUpIcon /> CTA
         </Button>
         <Button variant="primary">
           Primary
         </Button>
-        <Button variant="secondary">
-          <InfoIcon /> Secondary
-        </Button>
+        <Tooltip open content="Tooltip">
+          <Button variant="secondary">
+            <InfoIcon /> Secondary
+          </Button>
+        </Tooltip>
       </FlexLayout>
     </StackLayout>
   )

--- a/src/themes/sample.ts
+++ b/src/themes/sample.ts
@@ -61,6 +61,21 @@ export const simpleSample = {
           },
         },
       },
+      info: {
+        foreground: {
+          $type: "color",
+          // Purple 700
+          $value: {
+            r: 103,
+            g: 46,
+            b: 122,
+          },
+        },
+        border: {
+          $type: "color",
+          $value: `{salt.color.purple.700}`,
+        },
+      },
     },
   },
 };


### PR DESCRIPTION
Previously any update on token editors will result a complete rerender of sandpack, which will lose active file.

Wrap the app with `SandpackProvider` and use `sandpack.updateFile` to update file content so no re-render is needed for the context.